### PR TITLE
Fix build

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -23,8 +23,8 @@ namespace Aesop {
         public Gtk.Grid page_button_box;
         public Poppler.Document document;
         public double zoom = 1.25;
-        public double SIZE_MAX = 2.00;
-        public double SIZE_MIN = 0.25;
+        private const double SIZE_MAX = 2.00;
+        private const double SIZE_MIN = 0.25;
         public string filename;
         public int page_count = 1;
         public int total = 1;
@@ -378,7 +378,7 @@ namespace Aesop {
             }
             dialog.set_select_multiple (false);
             dialog.set_modal (true);
-	    
+
 	    var pdf_filter = new Gtk.FileFilter ();
             pdf_filter.set_filter_name (_("PDF File"));
             pdf_filter.add_mime_type ("application/pdf");
@@ -386,7 +386,7 @@ namespace Aesop {
 	    filters.append (pdf_filter);
 
 	    dialog.add_filter (pdf_filter);
-	    
+
             page_count = 1;
             dialog.show ();
             if (dialog.run () == Gtk.ResponseType.ACCEPT) {


### PR DESCRIPTION
This fails to build on NixOS like:
```asm
In file included from /nix/store/c6jvs50xrcy2m1nbrmpjwad51f62fcrx-gcc-8.3.0/lib/gcc/x86_64-unknown-linux-gnu/8.3.0/include/stdint.h:9,
                 from /nix/store/dk6v6zcyyrgx022jmjyi3vzng9c925vk-harfbuzz-2.6.4-dev/include/harfbuzz/hb-common.h:69,
                 from /nix/store/dk6v6zcyyrgx022jmjyi3vzng9c925vk-harfbuzz-2.6.4-dev/include/harfbuzz/hb-blob.h:34,
                 from /nix/store/dk6v6zcyyrgx022jmjyi3vzng9c925vk-harfbuzz-2.6.4-dev/include/harfbuzz/hb.h:31,
                 from /nix/store/6n6icd9pmmzdl7k39mdksv3k8y2z1bfn-pango-1.44.7-dev/include/pango-1.0/pango/pango-coverage.h:28,
                 from /nix/store/6n6icd9pmmzdl7k39mdksv3k8y2z1bfn-pango-1.44.7-dev/include/pango-1.0/pango/pango-font.h:25,
                 from /nix/store/6n6icd9pmmzdl7k39mdksv3k8y2z1bfn-pango-1.44.7-dev/include/pango-1.0/pango/pango-attributes.h:25,
                 from /nix/store/6n6icd9pmmzdl7k39mdksv3k8y2z1bfn-pango-1.44.7-dev/include/pango-1.0/pango/pango.h:25,
                 from /nix/store/i1akaw2n7ryr3gms1yap6i463j9819xw-gtk+3-3.24.12-dev/include/gtk-3.0/gdk/gdktypes.h:35,
                 from /nix/store/i1akaw2n7ryr3gms1yap6i463j9819xw-gtk+3-3.24.12-dev/include/gtk-3.0/gdk/gdkapplaunchcontext.h:30,
                 from /nix/store/i1akaw2n7ryr3gms1yap6i463j9819xw-gtk+3-3.24.12-dev/include/gtk-3.0/gdk/gdk.h:32,
                 from /nix/store/i1akaw2n7ryr3gms1yap6i463j9819xw-gtk+3-3.24.12-dev/include/gtk-3.0/gtk/gtk.h:30,
                 from com.github.lainsce.aesop@exe/src/MainWindow.c:21:
com.github.lainsce.aesop@exe/src/MainWindow.c:92:10: error: expected identifier or '(' before numeric constant
  gdouble SIZE_MAX;
          ^~~~~~~~
com.github.lainsce.aesop@exe/src/MainWindow.c: In function 'aesop_main_window_do_zoom':
com.github.lainsce.aesop@exe/src/MainWindow.c:644:27: error: expected identifier before '(' token
    if (self->zoom > self->SIZE_MAX) {
                           ^~~~~~~~
com.github.lainsce.aesop@exe/src/MainWindow.c: In function 'aesop_main_window_instance_init':
com.github.lainsce.aesop@exe/src/MainWindow.c:2235:8: error: expected identifier before '(' token
  self->SIZE_MAX = 2.00;
        ^~~~~~~~
```
Making this private should fix it.